### PR TITLE
Removed whitespace being generated by Inflector library on namespaces…

### DIFF
--- a/GraphODataTemplateWriter.Test/TypeHelperTests.cs
+++ b/GraphODataTemplateWriter.Test/TypeHelperTests.cs
@@ -91,5 +91,25 @@ namespace GraphODataTemplateWriter.Test
 
             Assert.AreEqual(expectedOutputString, sanitizedString, "GetSanitizedLongDescription is not handling escaped CRLF.");
         }
-    }
+
+        [TestMethod]
+        public void Namespace_Shouldnt_Contain_Whitespace_For_CSharp()
+        {
+            var testNamespace = new OdcmNamespace("Microsoft.OutlookServices");
+
+            var namespaceName = TypeHelperCSharp.GetNamespaceName(testNamespace);
+
+            Assert.AreEqual(namespaceName, "Microsoft.OutlookServices");
+        }
+
+        [TestMethod]
+        public void Namespace_Should_PascalCase_For_CSharp()
+        {
+            var testNamespace = new OdcmNamespace("microsoft.graph");
+
+            var namespaceName = TypeHelperCSharp.GetNamespaceName(testNamespace);
+
+            Assert.AreEqual(namespaceName, "Microsoft.Graph");
+        }
+     }
 }

--- a/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
+++ b/src/GraphODataTemplateWriter/CodeHelpers/CSharp/TypeHelperCSharp.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Graph.ODataTemplateWriter.CodeHelpers.CSharp
 
         public static string GetNamespaceName(this OdcmNamespace namespaceObject)
         {
-            return Inflector.Inflector.Titleize(namespaceObject.Name);
+            return Inflector.Inflector.Titleize(namespaceObject.Name).Replace(" ", "");
         }
 
         public static string GetToLowerFirstCharName(this OdcmProperty property)

--- a/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
+++ b/test/Typewriter.Test/Given_a_valid_metadata_file_to_Typewriter.cs
@@ -478,7 +478,7 @@ namespace Typewriter.Test
             {
                 Output = outputDirectory,
                 GenerationMode = GenerationMode.Transform,
-                Transform = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/mm/xslt/transforms/csdl/preprocess_csdl.xsl"
+                Transform = "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/transforms/csdl/preprocess_csdl.xsl"
 
             };
 


### PR DESCRIPTION
… (#234)

* Removed whitespace being generated by Inflector library when using the Titleize method on namespaces with multiple capitals, such as 'Microsoft.OfficeService' becoming 'Microsoft.Office Service'
* fix issue with test breaking build